### PR TITLE
feat: Use semantic-release docker plugin to tag and push images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,1 @@
+# Intentionally left empty - forces semantic-release to use the docker plugin (see https://github.com/marketplace/actions/open-sauced-release#docker)


### PR DESCRIPTION
We are using open-sauced/release GitHub action for semantic-release operations.
There is a requirement for the Dockerfile to exist at the root level in the repo.
See https://github.com/marketplace/actions/open-sauced-release